### PR TITLE
adjust provider output so that we arent printing the listening addresses twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.2"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b802d85aaf3a1cdb02b224ba472ebdea62014fccfcb269b95a4d76443b5ee5a"
+checksum = "49f9152d70e42172fdb87de2efd7327160beee37886027cf86f30a233d5b30b4"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.2"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
+checksum = "e067b220911598876eb55d52725ddcc201ffe3f0904018195973bc5b012ea2ca"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.4.1"
-source = "git+https://github.com/n0-computer/iroh.git?branch=ramfox/porcelain#72de1c0cc8548d2f1b9945c77a7d52d175869f2a"
+source = "git+https://github.com/n0-computer/iroh.git?branch=ramfox/porcelain#47444ba62003ed919772e886a17f9c732c296fdf"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -2739,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
 dependencies = [
  "bitflags",
  "errno",

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,11 +226,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            let addrs = provider.listen_addresses()?;
-            println!("real addrs:");
-            for addr in addrs {
-                println!("{addr}");
-            }
+            iroh::porcelain::display_provider_info(&provider)?;
 
             let provider2 = provider.clone();
             tokio::select! {


### PR DESCRIPTION
<img width="587" alt="Screen Shot 2023-04-19 at 01 38 42" src="https://user-images.githubusercontent.com/17440142/232927592-16c228fe-54cf-49f1-8ab5-356b288a41c3.png">

instead of the weird "real addrs:" println