### PR TITLE
feat:  streaming writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ name = "appa"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-compat",
  "async-trait",
  "backoff",
  "blake3",
@@ -226,6 +227,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b48b4ff0c2026db683dea961cd8ea874737f56cffca86fa84415eaddc51c00d"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = "0.1.37"
 hex = "0.4.3"
 walkdir = "2.3.3"
+async-compat = "0.2.1"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -215,7 +215,11 @@ impl Fs {
         self.write(dir, Cursor::new(content.into_bytes())).await
     }
 
-    pub async fn write(&mut self, dir: String, content: impl AsyncRead + Send + Unpin + 'static) -> Result<()> {
+    pub async fn write(
+        &mut self,
+        dir: String,
+        content: impl AsyncRead + Send + Unpin + 'static,
+    ) -> Result<()> {
         let path = PathSegments::from_path(dir)?;
 
         match path {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -229,7 +229,7 @@ impl Fs {
             PathSegments::Public(path) => {
                 let content_cid = self
                     .store
-                    .put_block_streaming(content, libipld::IpldCodec::Raw.into())
+                    .put_block_streaming(content, libipld::IpldCodec::Raw)
                     .await?;
 
                 self.public

--- a/src/store/flatfs.rs
+++ b/src/store/flatfs.rs
@@ -344,8 +344,8 @@ impl Flatfs {
                 if bytes.is_empty() {
                     break;
                 }
-                hasher.update(&bytes);
-                tempfile.write_all(&bytes).await?;
+                hasher.update(bytes);
+                tempfile.write_all(bytes).await?;
                 bytes.len()
             };
             reader.consume(len);


### PR DESCRIPTION
This adds support for streaming writes to import large files without filling up memory.
* `wnfs::PrivateFile` already supports this
* For public files, I added an `async fn put_block_streaming` to the `FlatFsStore`. It writes to a temp file, calculates the hash on the go and then renames to tempfile to the hash-based final path