### PR TITLE
Draft: FUSE support (read & write)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 [[package]]
 name = "wnfs"
 version = "0.1.20"
-source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#bc72ccecc683f47155b4297d13c951d6a6d3ff4c"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "wnfs-common"
 version = "0.1.20"
-source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#bc72ccecc683f47155b4297d13c951d6a6d3ff4c"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "wnfs-hamt"
 version = "0.1.20"
-source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#bc72ccecc683f47155b4297d13c951d6a6d3ff4c"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "wnfs-namefilter"
 version = "0.1.20"
-source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#bc72ccecc683f47155b4297d13c951d6a6d3ff4c"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,10 +162,12 @@ dependencies = [
  "chrono",
  "cid",
  "clap",
+ "fuser",
  "futures",
  "hex",
  "ignore",
  "iroh",
+ "libc",
  "libipld",
  "postcard",
  "rand 0.8.5",
@@ -1152,6 +1154,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "fuser"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5910691a0ececcc6eba8bb14029025c2d123e96a53db1533f6a4602861a5aaf7"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "users",
+ "zerocopy",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2217,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polyval"
@@ -3499,6 +3533,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,8 +3905,6 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 [[package]]
 name = "wnfs"
 version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b531786a5c5b1b535b948dccc78f6e70e4d72e717b4dbe719c76aadfbd57a46"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -3891,8 +3933,6 @@ dependencies = [
 [[package]]
 name = "wnfs-common"
 version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b597038ccffb005b16c042571e4849a81956b97a3ab13bac7304db19b84e41c1"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3910,8 +3950,6 @@ dependencies = [
 [[package]]
 name = "wnfs-hamt"
 version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ddf5eb6bf1ba319c924f5ada60fd1241e0d34d76420c5a25a89899a65e287d"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3935,8 +3973,6 @@ dependencies = [
 [[package]]
 name = "wnfs-namefilter"
 version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8edeb3b612bd49db3cd21b9bab66aeda2eb420905029b4d2e6ec6844c076611"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3994,6 +4030,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time 0.3.20",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,6 +3905,7 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 [[package]]
 name = "wnfs"
 version = "0.1.20"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -3933,6 +3934,7 @@ dependencies = [
 [[package]]
 name = "wnfs-common"
 version = "0.1.20"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3950,6 +3952,7 @@ dependencies = [
 [[package]]
 name = "wnfs-hamt"
 version = "0.1.20"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -3973,6 +3976,7 @@ dependencies = [
 [[package]]
 name = "wnfs-namefilter"
 version = "0.1.20"
+source = "git+https://github.com/frando/rs-wnfs?branch=fuse#94242126edb2c804e79aa2b496c2fc017004be90"
 dependencies = [
  "anyhow",
  "async-once-cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ libc = { version = "0.2.141", optional = true }
 tempfile = "3.5.0"
 
 [patch.crates-io]
-wnfs = { path = "../rs-wnfs/wnfs" }
+wnfs = { git = "https://github.com/frando/rs-wnfs", branch = "fuse" }
 
 [features]
 default = ["fuse"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,15 @@ tracing = "0.1.37"
 hex = "0.4.3"
 walkdir = "2.3.3"
 async-compat = "0.2.1"
+fuser = { version = "0.12.0", optional = true }
+libc = { version = "0.2.141", optional = true }
 
 [dev-dependencies]
 tempfile = "3.5.0"
+
+[patch.crates-io]
+wnfs = { path = "../rs-wnfs/wnfs" }
+
+[features]
+default = ["fuse"]
+fuse = ["dep:fuser", "dep:libc"]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -229,7 +229,7 @@ impl Fs {
             PathSegments::Public(path) => {
                 let content_cid = self
                     .store
-                    .put_block_streaming(content, libipld::IpldCodec::Raw.into())
+                    .put_block_streaming(content, libipld::IpldCodec::Raw)
                     .await?;
 
                 self.public

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,7 +10,7 @@ use chrono::Utc;
 use cid::Cid;
 use futures::StreamExt;
 use tokio::io::AsyncRead;
-use tracing::debug;
+use tracing::{debug};
 use wnfs::{
     common::{BlockStore, HashOutput},
     namefilter::Namefilter,
@@ -55,7 +55,7 @@ impl Commit {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Fs {
     store: store::Store,
     public: Rc<PublicDirectory>,
@@ -132,7 +132,7 @@ impl Fs {
             .context("private")?;
 
         debug!(
-            "Loaded commit: PrivateNode     at {}",
+            "Loaded commit: PrivateDirectory at {}",
             latest_commit.private_content_cid
         );
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,7 +10,7 @@ use chrono::Utc;
 use cid::Cid;
 use futures::StreamExt;
 use tokio::io::AsyncRead;
-use tracing::{debug};
+use tracing::debug;
 use wnfs::{
     common::{BlockStore, HashOutput},
     namefilter::Namefilter,
@@ -215,7 +215,11 @@ impl Fs {
         self.write(dir, Cursor::new(content.into_bytes())).await
     }
 
-    pub async fn write(&mut self, dir: String, content: impl AsyncRead + Send + Unpin + 'static) -> Result<()> {
+    pub async fn write(
+        &mut self,
+        dir: String,
+        content: impl AsyncRead + Send + Unpin + 'static,
+    ) -> Result<()> {
         let path = PathSegments::from_path(dir)?;
 
         match path {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -450,7 +450,7 @@ impl Fs {
                     .ok_or_else(|| anyhow::anyhow!("Block not found"))?;
                 tokio::task::spawn_blocking(move || {
                     let meta = file.metadata()?;
-                    let max_size = (offset + size).min(meta.len() as usize);
+                    let max_size = (offset + size).min(meta.len() as usize - offset);
                     if max_size == 0 {
                         return Ok(vec![]);
                     }

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -167,8 +167,8 @@ impl FuseFs {
             NodeKind::File => FileType::RegularFile,
         };
         let perm = match node.kind() {
-            NodeKind::Directory => 0o555,
-            NodeKind::File => 0o444,
+            NodeKind::Directory => 0o755,
+            NodeKind::File => 0o644,
         };
         let size = node.size(&self.fs).unwrap_or(0);
         let nlink = match node.kind() {

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -493,6 +493,45 @@ impl Filesystem for FuseFs {
         }
     }
 
+    // TODO: Properly do this
+    fn setattr(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        _size: Option<u64>,
+        _atime: Option<fuser::TimeOrNow>,
+        _mtime: Option<fuser::TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<u64>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<u32>,
+        reply: ReplyAttr,
+    ) {
+        let attr = FileAttr {
+            ino,
+            size: 0,
+            blocks: 0,
+            nlink: 2,
+            perm: 0o755,
+            uid: self.config.uid,
+            gid: self.config.gid,
+            rdev: 0,
+            flags: 0,
+            blksize: BLOCK_SIZE as u32,
+            kind: FileType::RegularFile,
+            atime: SystemTime::now(),
+            mtime: SystemTime::now(),
+            ctime: SystemTime::now(),
+            crtime: SystemTime::now(),
+        };
+        reply.attr(&TTL, &attr)
+    }
+
     fn release(
         &mut self,
         _req: &Request<'_>,

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -1,0 +1,419 @@
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::future::Future;
+use std::path::Path;
+use std::time::{Duration, UNIX_EPOCH};
+
+use fuser::{
+    FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
+    Request,
+};
+use libc::ENOENT;
+use tracing::{debug, trace};
+use wnfs::private::PrivateNode;
+use wnfs::public::PublicNode;
+
+use crate::fs::{Fs, Node, NodeKind};
+
+const TTL: Duration = Duration::from_secs(1); // 1 second
+// const ROOT_INO: u64 = 1;
+const BLOCK_SIZE: usize = 512;
+
+const ROOT_ATTR: FileAttr = FileAttr {
+    ino: 1,
+    size: 0,
+    blocks: 0,
+    nlink: 2,
+    perm: 0o555,
+    uid: 1000,
+    gid: 1000,
+    rdev: 0,
+    flags: 0,
+    blksize: BLOCK_SIZE as u32,
+    kind: FileType::Directory,
+    atime: UNIX_EPOCH,
+    mtime: UNIX_EPOCH,
+    ctime: UNIX_EPOCH,
+    crtime: UNIX_EPOCH,
+};
+
+/// Mount a filesystem
+///
+/// Blocks forever until Ctrl-C.
+/// TODO: use spawn_mount once wnfs is Send.
+pub fn mount(fs: Fs, mountpoint: impl AsRef<Path>) -> anyhow::Result<()> {
+    let fs = FuseFs::new(fs);
+    let mountpoint = mountpoint.as_ref().to_owned();
+    let options = vec![
+        MountOption::RW,
+        MountOption::FSName("appa-wnfs".to_string()),
+        MountOption::AutoUnmount,
+        MountOption::AllowRoot,
+    ];
+    debug!("mount FUSE at {mountpoint:?}");
+    fuser::mount2(fs, mountpoint, &options)?;
+    Ok(())
+}
+
+/// Inode index for a filesystem.
+///
+/// This is a partial view of the filesystem and contains only nodes that have been accessed
+/// in the current session. Inode numbers are assigned sequentially on first use.
+#[derive(Default, Debug)]
+pub struct Inodes {
+    inodes: HashMap<u64, Inode>,
+    by_path: HashMap<String, u64>,
+    counter: u64,
+}
+
+impl Inodes {
+    pub fn push(&mut self, path: String) -> u64 {
+        // pub fn push(&mut self, path: String, kind: FileType) -> u64 {
+        self.counter += 1;
+        let ino = self.counter;
+        let inode = Inode::new(ino, path);
+        self.by_path.insert(inode.path.clone(), ino);
+        self.inodes.insert(ino, inode);
+        ino
+    }
+    pub fn get(&self, ino: u64) -> Option<&Inode> {
+        self.inodes.get(&ino)
+    }
+
+    pub fn get_path(&self, ino: u64) -> Option<&String> {
+        self.get(ino).map(|node| &node.path)
+    }
+
+    pub fn get_by_path(&self, path: &str) -> Option<&Inode> {
+        self.by_path.get(path).and_then(|ino| self.inodes.get(ino))
+    }
+
+    pub fn get_or_push(&mut self, path: &str) -> Inode {
+        let id = if let Some(id) = self.by_path.get(path) {
+            *id
+        } else {
+            self.push(path.to_string())
+        };
+        self.get(id).unwrap().clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Inode {
+    pub path: String,
+    pub ino: u64,
+}
+
+impl Inode {
+    pub fn new(ino: u64, path: String) -> Self {
+        Self { path, ino }
+    }
+}
+
+pub struct FuseFs {
+    pub(crate) fs: Fs,
+    pub(crate) inodes: Inodes,
+}
+
+impl FuseFs {
+    pub fn new(fs: Fs) -> Self {
+        let mut inodes = Inodes::default();
+        // Init root inodes.
+        inodes.push("/".to_string());
+        inodes.push("/private".to_string());
+        inodes.push("/public".to_string());
+        Self { fs, inodes }
+    }
+
+    fn node_to_attr(&self, ino: u64, node: &Node) -> FileAttr {
+        if matches!(node, Node::Root) {
+            return ROOT_ATTR;
+        }
+        let metadata = match node {
+            Node::Private(PrivateNode::File(file)) => file.get_metadata(),
+            Node::Private(PrivateNode::Dir(dir)) => dir.get_metadata(),
+            Node::Public(PublicNode::File(file)) => file.get_metadata(),
+            Node::Public(PublicNode::Dir(dir)) => dir.get_metadata(),
+            Node::Root => unreachable!(),
+        };
+        let kind = match node.kind() {
+            NodeKind::Directory => FileType::Directory,
+            NodeKind::File => FileType::RegularFile,
+        };
+        let perm = match node.kind() {
+            NodeKind::Directory => 0o555,
+            NodeKind::File => 0x444,
+        };
+        let size = node.size(&self.fs).unwrap_or(0);
+        let nlink = match node.kind() {
+            NodeKind::Directory => 2,
+            NodeKind::File => 1,
+        };
+        let blocks = size / BLOCK_SIZE as u64;
+        let mtime = metadata
+            .get_modified()
+            .map(|x| x.into())
+            .unwrap_or(UNIX_EPOCH);
+        let ctime = metadata
+            .get_created()
+            .map(|x| x.into())
+            .unwrap_or(UNIX_EPOCH);
+        FileAttr {
+            ino,
+            size: size as u64,
+            blocks: blocks as u64,
+            nlink,
+            perm,
+            uid: 1000,
+            gid: 1000,
+            rdev: 0,
+            flags: 0,
+            blksize: BLOCK_SIZE as u32,
+            kind,
+            atime: mtime,
+            mtime,
+            ctime,
+            crtime: ctime,
+        }
+    }
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    futures::executor::block_on(future)
+}
+
+impl Filesystem for FuseFs {
+    fn lookup(&mut self, _req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        trace!("lookup: i{parent} {name:?}");
+        let Some(path) = self.inodes.get_path(parent) else {
+            trace!("  ENOENT");
+            reply.error(ENOENT);
+            return;
+        };
+        let path = push_segment(&path, &name.to_str().unwrap());
+        let Inode { ino, .. } = self.inodes.get_or_push(&path);
+        match block_on(self.fs.get_node(path)) {
+            Ok(Some(node)) => {
+                let attr = self.node_to_attr(ino, &node);
+                trace!("  ok {attr:?}");
+                reply.entry(&TTL, &attr, 0);
+            }
+            Ok(None) => {
+                trace!("  ENOENT (not found)");
+                reply.error(ENOENT);
+            }
+            Err(err) => {
+                trace!("  ENOENT ({err})");
+                reply.error(ENOENT);
+            }
+        }
+    }
+
+    fn getattr(&mut self, _req: &Request, ino: u64, reply: ReplyAttr) {
+        trace!("getattr: i{ino}");
+
+        let Some(path) = self.inodes.get_path(ino) else {
+                trace!("  ENOENT (ino not found)");
+                reply.error(ENOENT);
+                return;
+            };
+        let Ok(Some(node)) = block_on(self.fs.get_node(path.into())) else {
+                trace!("  ENOENT (path not found)");
+                reply.error(ENOENT);
+                return;
+            };
+        let attr = self.node_to_attr(ino, &node);
+        trace!("  ok {attr:?}");
+        reply.attr(&TTL, &attr)
+    }
+
+    fn read(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        size: u32,
+        _flags: i32,
+        _lock: Option<u64>,
+        reply: ReplyData,
+    ) {
+        trace!("read: i{ino} offset {offset} size {size}");
+        let Some(path) = self.inodes.get_path(ino) else {
+              trace!("  ENOENT (ino not found)");
+              reply.error(ENOENT);
+              return;
+        };
+        let content = block_on(
+            self.fs
+                .read_file_at(path.into(), offset as usize, size as usize),
+        );
+        // let content = block_on(self.wnfs.read_file(&path));
+        match content {
+            Ok(data) => {
+                trace!("  ok, len {}", data.len());
+                reply.data(&data)
+            }
+            Err(err) => {
+                trace!("  ENOENT ({err})");
+                reply.error(ENOENT);
+            }
+        }
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &Request,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        trace!("readdir: i{ino} offset {offset}");
+        let path = {
+            // We're cloning the path segments here to not keep an immutable borrow to self.inodes around.
+            // TODO: Maybe always wrap Inode an Rc
+            let Some(path) = self.inodes.get_path(ino) else {
+                trace!("  ENOENT (ino not found)");
+                reply.error(ENOENT);
+                return;
+            };
+            path.clone()
+        };
+
+        let Ok(dir) = block_on(self.fs.ls(path.clone())) else {
+            trace!("  ENOENT (failed to get metadata)");
+            reply.error(ENOENT);
+            return;
+        };
+        // let dir = if path.len() == 0 {
+        //     self.fs.private_root()
+        // } else {
+        //     let Ok(Some(PrivateNode::Dir(dir))) = block_on(self.fs.get_node(&path)) else {
+        //           trace!("  ENOENT (dir not found)");
+        //           reply.error(ENOENT);
+        //           return;
+        //     };
+        //     dir
+        // };
+
+        let mut entries = vec![
+            (ino, FileType::Directory, ".".to_string()),
+            (ino, FileType::Directory, "..".to_string()),
+        ];
+
+        for (name, _metadata) in dir {
+            let path = push_segment(&path, &name);
+
+            // We need to know for each entry whether it's a file or a directory.
+            // However, the metadata from `ls` does not have that info.
+            // Therefore we fetch all nodes again.
+            // TODO: Solve by making wnfs return nodes, not metadata, on ls
+            let node = block_on(self.fs.get_node(path.clone()));
+            if let Ok(Some(node)) = node {
+                let kind = match node.kind() {
+                    NodeKind::File => FileType::Directory,
+                    NodeKind::Directory => FileType::RegularFile,
+                };
+                let ino = self.inodes.get_or_push(&path);
+                entries.push((ino.ino, kind, name));
+            }
+        }
+        trace!("  ok {entries:?}");
+
+        for (i, entry) in entries.into_iter().enumerate().skip(offset as usize) {
+            // i + 1 means the index of the next entry
+            if reply.add(entry.0, (i + 1) as i64, entry.1, entry.2) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+
+    // fn open(&mut self, _req: &Request<'_>, _ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
+    // }
+
+    fn mkdir(
+        &mut self,
+        _req: &Request<'_>,
+        parent: u64,
+        name: &OsStr,
+        _mode: u32,
+        _umask: u32,
+        reply: ReplyEntry,
+    ) {
+        trace!("mkdir : i{parent} {name:?}");
+        let Some(path) = self.inodes.get_path(parent) else {
+            trace!("  ENOENT: parent not found");
+            reply.error(ENOENT);
+            return;
+        };
+        let path = push_segment(path, name.to_str().unwrap());
+        match block_on(self.fs.mkdir(path.clone())) {
+            Ok(_) => match block_on(self.fs.get_node(path.clone())) {
+                Ok(Some(node)) => {
+                    let ino = self.inodes.get_or_push(&path);
+                    let attr = self.node_to_attr(ino.ino, &node);
+                    trace!("  ok, created! ino {}", ino.ino);
+                    reply.entry(&TTL, &attr, 0);
+                }
+                Err(_) | Ok(None) => {
+                    trace!("  ENOENT, failed to find created dir");
+                    reply.error(ENOENT);
+                }
+            },
+            Err(err) => {
+                trace!("  ENOENT, failed to create dir: {err}");
+                reply.error(ENOENT);
+            }
+        }
+    }
+
+    fn write(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        data: &[u8],
+        _write_flags: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: fuser::ReplyWrite,
+    ) {
+        let size = data.len();
+        trace!("write i{ino} offset {offset} size {size}");
+        reply.error(ENOENT);
+    }
+}
+
+fn push_segment(path: &str, name: &str) -> String {
+    format!("{}/{}", path, name)
+}
+
+// TODO: Write tests once wnfs is Send
+// #[cfg(test)]
+// mod test {
+//     use std::{time::Duration, fs};
+//
+//     use crate::{store::flatfs::FlatFsStore, fs::Wnfs};
+//
+//     use super::mount;
+//
+//     #[tokio::test]
+//     async fn test_fuse_read() {
+//         let dir = tempfile::tempdir().unwrap();
+//         let mountpoint = tempfile::tempdir().unwrap();
+//         let store = FlatFsStore::new(dir).unwrap();
+//         let fs = Wnfs::with_store(store, "test").await.unwrap();
+//         let path = &["foo".to_string()];
+//         fs::write(path, "rev1".as_bytes().to_vec());
+//         let mountpoint2 = mountpoint.
+//         std::thread::spawn(move || {
+//             std::thread::sleep(Duration::from_millis(100));
+//             let read = fs::read_to_string(mountpoint2.join("foo")).unwrap();
+//             assert_eq!("rev1", read.as_str(), "read ok");
+//         });
+//         mount(fs, mountpoint);
+//     }
+// }

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::future::{Future};
+use std::future::Future;
 use std::os::unix::prelude::MetadataExt;
 use std::path::Path;
 use std::pin::Pin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod fs;
-pub mod hash_manifest;
-pub mod store;
 #[cfg(feature = "fuse")]
 pub mod fuse;
+pub mod hash_manifest;
+pub mod store;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod fs;
 pub mod hash_manifest;
 pub mod store;
+#[cfg(feature = "fuse")]
+pub mod fuse;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,14 @@ enum Commands {
         #[arg(value_name = "TARGET")]
         target: String,
     },
+
+    #[cfg(feature = "fuse")]
+    /// Mount with FUSE
+    Mount {
+        /// Directory to mount at
+        #[arg(value_name = "MOUNTPOINT")]
+        mountpoint: String
+    }
 }
 
 #[tokio::main]
@@ -257,6 +265,12 @@ async fn main() -> Result<()> {
             fs.import(&source, &target).await?;
             fs.commit().await?;
             println!("Imported {source} to {target}");
+        }
+
+        #[cfg(feature = "fuse")]
+        Commands::Mount { mountpoint } => {
+            let fs = Fs::load(&ROOT_DIR).await?;
+            appa::fuse::mount(fs, mountpoint)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,8 +269,9 @@ async fn main() -> Result<()> {
 
         #[cfg(feature = "fuse")]
         Commands::Mount { mountpoint } => {
-            let fs = || async move { Fs::load(&ROOT_DIR).await };
-            appa::fuse::mount(fs, mountpoint, None)?;
+            let make_fs = || async move { Fs::load(&ROOT_DIR).await };
+            let handle = appa::fuse::mount(make_fs, mountpoint).await?;
+            tokio::task::spawn_blocking(move || handle.join()).await??;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,8 +269,8 @@ async fn main() -> Result<()> {
 
         #[cfg(feature = "fuse")]
         Commands::Mount { mountpoint } => {
-            let fs = Fs::load(&ROOT_DIR).await?;
-            appa::fuse::mount(fs, mountpoint)?;
+            let fs = || async move { Fs::load(&ROOT_DIR).await };
+            appa::fuse::mount(fs, mountpoint, None)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,8 +103,8 @@ enum Commands {
     Mount {
         /// Directory to mount at
         #[arg(value_name = "MOUNTPOINT")]
-        mountpoint: String
-    }
+        mountpoint: String,
+    },
 }
 
 #[tokio::main]

--- a/src/store/flatfs.rs
+++ b/src/store/flatfs.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
-    fs::{self, File}, io,
+    fs::{self, File},
+    io,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},

--- a/src/store/flatfs.rs
+++ b/src/store/flatfs.rs
@@ -364,8 +364,8 @@ impl Flatfs {
                 if bytes.is_empty() {
                     break;
                 }
-                hasher.update(&bytes);
-                tempfile.write_all(&bytes).await?;
+                hasher.update(bytes);
+                tempfile.write_all(bytes).await?;
                 bytes.len()
             };
             reader.consume(len);

--- a/src/store/flatfs.rs
+++ b/src/store/flatfs.rs
@@ -121,9 +121,10 @@ impl Flatfs {
         Ok(value)
     }
 
-    /// Open the file under the given key in read-only mode.
-    pub fn get_as_file(&self, key: &str) -> Result<Option<File>> {
-        let filepath = self.as_path(key);
+    /// Open the underlying file for a block in read-only mode.
+    pub fn get_block_as_file(&self, cid: cid::Cid) -> Result<Option<File>> {
+        let key = Self::key_for_cid(cid);
+        let filepath = self.as_path(&key);
 
         let value = retry(|| match fs::File::open(&filepath) {
             Ok(res) => Ok(Some(res)),


### PR DESCRIPTION
Supersedes #6 

Allows to mount an appa WNFS with FUSE. Not all operations are supported yet. Read works as in #6 (using https://github.com/wnfs-wg/rs-wnfs/pull/237).

The news is: It does streaming writes now! Builds on top of #10 and I *think* I correctly managed to create a thread-local tokio runtime.

A first test with read and write passes :-)

What still needs to be done is to wrap the `Fs` instance in an `RwLock`. I think concurrent writes would fail at the moment (only one of them would be included in the latest commit).