### PR TITLE
fix(deps): Point to commit instead of branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "car-mirror"
 version = "0.1.0"
-source = "git+https://github.com/fission-codes/rs-car-mirror.git?branch=matheus23/streaming#ec0a4d5665e22ee61372bd687bd54e5739451c76"
+source = "git+https://github.com/fission-codes/rs-car-mirror.git?rev=ec0a4d56#ec0a4d5665e22ee61372bd687bd54e5739451c76"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.25"
 bytes = "1.4"
 blake3 = "1.3"
 chrono = "0.4.24"
-car-mirror = { git = "https://github.com/fission-codes/rs-car-mirror.git", branch = "matheus23/streaming", features = ["quick_cache"] }
+car-mirror = { git = "https://github.com/fission-codes/rs-car-mirror.git", rev = "ec0a4d56", features = ["quick_cache"] }
 cid = "0.10"
 clap = { version = "4.2", features = ["derive"] }
 ignore = "0.4.20"


### PR DESCRIPTION
Currently, Cargo fails to find `https://github.com/fission-codes/rs-car-mirror.git?branch=matheus23/streaming` because that branch no longer exists.