### PR TITLE
feat: Syncing from `path` on other node

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@ enum Commands {
         /// The ticket printed on the other node's listen command
         #[arg(value_name = "TICKET")]
         ticket: String,
+        /// The path of a directory on the other node to sync from
+        #[arg(value_name = "PATH")]
+        path: String,
     },
     /// The appa debugging tool
     Doctor {
@@ -171,8 +174,8 @@ async fn main() -> Result<()> {
         Commands::Listen => {
             listen().await?;
         }
-        Commands::Sync { ticket } => {
-            sync(ticket).await?;
+        Commands::Sync { ticket, path } => {
+            sync(ticket, path).await?;
         }
         Commands::Nfsserve => {
             const HOSTPORT: u32 = 11111;

--- a/src/store/flatfs.rs
+++ b/src/store/flatfs.rs
@@ -72,7 +72,7 @@ impl Flatfs {
 
         // Rename after successfull write
         retry(|| fs::rename(&temp_filepath, &filepath))
-            .with_context(|| format!("Failed to reaname: {temp_filepath:?} -> {filepath:?}"))?;
+            .with_context(|| format!("Failed to rename: {temp_filepath:?} -> {filepath:?}"))?;
 
         self.disk_usage
             .fetch_add(value.len() as u64, Ordering::SeqCst);


### PR DESCRIPTION
Currently, this overwrites a syncing node's private root with the contents of a `path` on a listening node.